### PR TITLE
fix: add Linux desktop integration and fix startup/shortcut issues

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,8 +18,8 @@ jobs:
           enable-cache: true
       - name: Check OpenSSL Version
         run: uv run python -c "import ssl; print(ssl.OPENSSL_VERSION)"
-      - name: Install VLC
-        run: sudo apt-get update && sudo apt-get install -y vlc
+      - name: Install VLC and xcb dependencies
+        run: sudo apt-get update && sudo apt-get install -y vlc libxcb-cursor0
       - name: Sync dependencies with uv
         run: uv sync --frozen --dev
       - name: Package App with PyInstaller for Linux

--- a/README.md
+++ b/README.md
@@ -19,6 +19,30 @@ pip install -r requirements.txt
 python main.py
 ```
 
+### Linux Desktop Integration
+
+After downloading the release binary or cloning the repo, you can install QiTV into your application menu so it persists across reboots:
+
+**Using the release binary:**
+```bash
+chmod +x qitv-linux
+git clone https://github.com/ozankaraali/QiTV/  # needed for install script and icon
+cd QiTV
+./scripts/install-linux.sh /path/to/qitv-linux
+```
+
+**Using the development (venv) setup:**
+```bash
+# After the initial setup above:
+./scripts/install-linux.sh
+```
+
+This installs a desktop entry and icon so QiTV appears in your application menu. The desktop entry uses absolute paths, so it works after rebooting without needing to re-activate the virtual environment.
+
+**Troubleshooting on Linux:**
+- If the release binary fails with Qt/xcb plugin errors, install xcb-cursor: `sudo apt install libxcb-cursor0` (Debian/Ubuntu) or `sudo dnf install xcb-util-cursor` (Fedora).
+- Make sure `~/.local/bin` is in your PATH. Add `export PATH="$HOME/.local/bin:$PATH"` to your `~/.bashrc` if needed.
+
 ## Usage
 
 You could use this software as a IPTV player or as a STB client. It bundles [a list of publicly available IPTV channels](https://github.com/iptv-org/iptv) from around the world for you to start quickly using or test the application. You can delete that playlist entry if you want from your computer after registering your playlists / STB player details.

--- a/assets/qitv.desktop
+++ b/assets/qitv.desktop
@@ -1,0 +1,10 @@
+[Desktop Entry]
+Name=QiTV
+Comment=A cross-platform IPTV and STB player client
+Exec=qitv-linux
+Icon=qitv
+Terminal=false
+Type=Application
+Categories=AudioVideo;Video;Player;TV;
+Keywords=IPTV;STB;TV;streaming;video;
+StartupWMClass=qitv

--- a/main.py
+++ b/main.py
@@ -87,6 +87,13 @@ if __name__ == "__main__":
 
     icon_path = "assets/qitv.png"
 
+    # Resolve icon path for PyInstaller bundles
+    if hasattr(sys, "_MEIPASS"):
+        if platform.system() == "Windows":
+            icon_path = os.path.join(sys._MEIPASS, "assets", "qitv.ico")
+        else:
+            icon_path = os.path.join(sys._MEIPASS, "assets", "qitv.png")
+
     config_manager = ConfigManager()
     image_manager = ImageManager(config_manager, config_manager.max_cache_image_size * 1024 * 1024)
     provider_manager = ProviderManager(config_manager)
@@ -95,8 +102,6 @@ if __name__ == "__main__":
     if platform.system() == "Windows":
         myappid = f"com.ozankaraali.qitv.{get_app_version()}"
         ctypes.windll.shell32.SetCurrentProcessExplicitAppUserModelID(myappid)  # type: ignore
-        if hasattr(sys, "_MEIPASS"):
-            icon_path = sys._MEIPASS + "\\assets\\qitv.ico"
 
     app.setWindowIcon(QtGui.QIcon(icon_path))
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "qitv"
-version = "1.12.0"
+version = "1.12.1"
 description = "A cross-platform STB and IPTV player client"
 requires-python = ">=3.14"
 dependencies = [

--- a/qitv-linux.spec
+++ b/qitv-linux.spec
@@ -28,6 +28,14 @@ for file in os.listdir(VLC_PATH):
     if file.startswith("libvlccore.so"):
         libvlccore_version = file
 
+# Find libxcb-cursor (required by Qt xcb platform plugin on many distros)
+xcb_cursor_binaries = []
+for file in os.listdir(VLC_PATH):
+    if file.startswith("libxcb-cursor.so"):
+        xcb_cursor_binaries.append(
+            (file, os.path.join(VLC_PATH, file), "BINARY")
+        )
+
 a = Analysis(
     ['main.py'],
     pathex=[VLC_PATH],
@@ -36,6 +44,7 @@ a = Analysis(
     ],
     datas=[
         ('pyproject.toml', '.'),  # Include pyproject.toml so version can be read
+        ('assets', 'assets'),  # Include icons and desktop file
     ],
     hiddenimports=[],
     hookspath=[],
@@ -56,8 +65,8 @@ exe = EXE(
     a.scripts,
     a.binaries + [
         (libvlc_version, os.path.join(VLC_PATH, libvlc_version), "BINARY"),
-        (libvlccore_version, os.path.join(VLC_PATH, libvlccore_version), "BINARY")
-    ],
+        (libvlccore_version, os.path.join(VLC_PATH, libvlccore_version), "BINARY"),
+    ] + xcb_cursor_binaries,
     a.datas,
     [],
     name='qitv',

--- a/scripts/install-linux.sh
+++ b/scripts/install-linux.sh
@@ -1,0 +1,80 @@
+#!/bin/bash
+# QiTV Linux installer
+# Creates a desktop shortcut and installs the icon so QiTV appears
+# in your application menu and survives reboots.
+#
+# Usage:
+#   For release binary:  ./scripts/install-linux.sh /path/to/qitv-linux
+#   For dev (venv) mode: ./scripts/install-linux.sh
+#
+# The script installs to ~/.local (no root required).
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_DIR="$(dirname "$SCRIPT_DIR")"
+
+ICON_SRC="$REPO_DIR/assets/qitv.png"
+DESKTOP_SRC="$REPO_DIR/assets/qitv.desktop"
+
+ICON_DIR="$HOME/.local/share/icons/hicolor/256x256/apps"
+DESKTOP_DIR="$HOME/.local/share/applications"
+BIN_DIR="$HOME/.local/bin"
+
+# --- helpers ---------------------------------------------------------------
+die() { echo "Error: $*" >&2; exit 1; }
+
+install_icon() {
+    mkdir -p "$ICON_DIR"
+    cp "$ICON_SRC" "$ICON_DIR/qitv.png"
+    echo "Installed icon to $ICON_DIR/qitv.png"
+}
+
+install_desktop_entry() {
+    local exec_line="$1"
+    mkdir -p "$DESKTOP_DIR"
+
+    # Write desktop file with the correct Exec line
+    sed "s|^Exec=.*|Exec=$exec_line|" "$DESKTOP_SRC" > "$DESKTOP_DIR/qitv.desktop"
+    chmod +x "$DESKTOP_DIR/qitv.desktop"
+    echo "Installed desktop entry to $DESKTOP_DIR/qitv.desktop"
+
+    # Update desktop database if available
+    if command -v update-desktop-database &>/dev/null; then
+        update-desktop-database "$DESKTOP_DIR" 2>/dev/null || true
+    fi
+}
+
+# --- main ------------------------------------------------------------------
+if [ $# -ge 1 ]; then
+    # ---- Release binary mode ----
+    BINARY="$(realpath "$1")"
+    [ -f "$BINARY" ] || die "File not found: $1"
+    [ -x "$BINARY" ] || chmod +x "$BINARY"
+
+    # Copy to ~/.local/bin for PATH-based launching
+    mkdir -p "$BIN_DIR"
+    cp "$BINARY" "$BIN_DIR/qitv-linux"
+    chmod +x "$BIN_DIR/qitv-linux"
+    echo "Installed binary to $BIN_DIR/qitv-linux"
+
+    install_icon
+    install_desktop_entry "$BIN_DIR/qitv-linux"
+else
+    # ---- Development / venv mode ----
+    VENV_PYTHON="$REPO_DIR/venv/bin/python"
+    MAIN_PY="$REPO_DIR/main.py"
+
+    [ -f "$VENV_PYTHON" ] || die "Virtual environment not found at $REPO_DIR/venv/. Run: python3 -m venv venv && source venv/bin/activate && pip install -r requirements.txt"
+    [ -f "$MAIN_PY" ] || die "main.py not found at $REPO_DIR"
+
+    install_icon
+    install_desktop_entry "$VENV_PYTHON $MAIN_PY"
+fi
+
+echo ""
+echo "QiTV has been installed. You should now find it in your application menu."
+echo "If it does not appear immediately, log out and log back in."
+echo ""
+echo "Tip: make sure ~/.local/bin is in your PATH. Add this to your ~/.bashrc:"
+echo '  export PATH="$HOME/.local/bin:$PATH"'


### PR DESCRIPTION
- Add .desktop file and install script so QiTV appears in the app menu
  and launches correctly after reboots (no manual venv activation needed)
- Bundle libxcb-cursor in PyInstaller build to fix Qt xcb plugin crash
  on distros where libxcb-cursor0 is not installed by default
- Fix icon path resolution for Linux PyInstaller bundles (was only
  handled for Windows)
- Include assets directory in Linux PyInstaller spec
- Update README with Linux desktop integration instructions and
  troubleshooting tips

https://claude.ai/code/session_01R5D8qN6vUNCmMqKidKmPYZ