### PR TITLE
Upgrade pyqtdarktheme to fork version 2.3.4

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "qitv"
-version = "1.12.1"
+version = "1.12.2"
 description = "A cross-platform STB and IPTV player client"
 requires-python = ">=3.14"
 dependencies = [
@@ -9,7 +9,7 @@ dependencies = [
     "mpv>=1.0.7",
     "orjson>=3.11.5",
     "packaging>=25.0",
-    "pyqtdarktheme==2.1.0",
+    "pyqtdarktheme-fork>=2.3.4",
     "pyside6>=6.10.0",
     "python-vlc==3.0.21203",
     "requests>=2.32.5",

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ requests>=2.32.5
 urllib3>=2.6.3
 URLObject~=2.4.3
 m3u-parser
-pyqtdarktheme==2.1.0
+pyqtdarktheme-fork>=2.3.4
 PySide6
 orjson>=3.11.5
 tzlocal


### PR DESCRIPTION
## Summary
Updates the pyqtdarktheme dependency to use a community fork version that provides newer features and improvements.

## Changes
- Replaced `pyqtdarktheme==2.1.0` with `pyqtdarktheme-fork>=2.3.4` in both `pyproject.toml` and `requirements.txt`
- Updated version constraint from pinned (==) to minimum version (>=) to allow for future patch updates
- Bumped project version to 1.12.2

## Details
The switch to the fork version enables access to newer functionality while maintaining compatibility with the existing codebase. The relaxed version constraint allows for automatic inclusion of bug fixes and minor updates from the fork maintainers.

https://claude.ai/code/session_01Szqp3nwbzxqGUaxD7PYEiV