### PR TITLE
Improve favorites filtering and content type button exclusivity

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "qitv"
-version = "1.12.2"
+version = "1.12.3"
 description = "A cross-platform STB and IPTV player client"
 requires-python = ">=3.14"
 dependencies = [

--- a/widgets/sidebar.py
+++ b/widgets/sidebar.py
@@ -4,6 +4,7 @@ import logging
 
 from PySide6.QtCore import Qt, Signal
 from PySide6.QtWidgets import (
+    QButtonGroup,
     QComboBox,
     QFrame,
     QLabel,
@@ -67,6 +68,8 @@ class Sidebar(QWidget):
 
         # --- Content type section ---
         self._type_buttons = {}
+        self._type_button_group = QButtonGroup(self)
+        self._type_button_group.setExclusive(True)
         for label, content_type in [
             ("Channels", "itv"),
             ("Movies", "vod"),
@@ -74,6 +77,7 @@ class Sidebar(QWidget):
         ]:
             btn = SidebarButton(label)
             btn.clicked.connect(lambda checked, ct=content_type: self._on_content_type(ct))
+            self._type_button_group.addButton(btn)
             self._type_buttons[content_type] = btn
             layout.addWidget(btn)
         self._type_buttons["itv"].setChecked(True)


### PR DESCRIPTION
## Summary
This PR enhances the favorites feature by implementing a flat favorites view at the category level and improves the content type button UI by ensuring only one type button can be selected at a time.

## Key Changes

- **Flat Favorites View**: When the favorites filter is enabled at the category level, the app now displays a consolidated flat list of all favorited items across all categories, rather than just filtering the current view. This provides a better user experience for browsing all favorites in one place.

- **Favorites View Logic**: 
  - Added `_show_favorites_flat()` method that gathers items from all categories, filters to only favorites, and displays them with appropriate empty state handling
  - Updated `_on_sidebar_favorites()` to handle three distinct scenarios: enabling favorites at category level, disabling favorites at root level, and filtering within existing views
  - Added safeguard in `filter_content()` to switch to flat favorites view when search is performed with favorites active at category level

- **Content Type Button Exclusivity**: Wrapped the content type buttons (Channels, Movies, Series) in a `QButtonGroup` with exclusive mode enabled, ensuring only one content type can be selected at a time and preventing UI inconsistencies.

- **Version Bump**: Updated version from 1.12.2 to 1.12.3

## Implementation Details

- The flat favorites view properly handles both flat content structures (with `sorted_channels`) and nested category structures
- Display type is intelligently mapped from content type (itv→channel, series→serie, vod→movie) for user-friendly messaging
- The back button is hidden when viewing flat favorites to maintain proper navigation state
- Empty state is gracefully handled with an informative message when no favorites exist

https://claude.ai/code/session_01NZrCmVoqJci3MLCnWpA53z