### PR TITLE
Fix dialog button truncation by setting minimum label width

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "qitv"
-version = "1.13.0"
+version = "1.12.4"
 description = "A cross-platform STB and IPTV player client"
 requires-python = ">=3.14"
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "qitv"
-version = "1.12.3"
+version = "1.13.0"
 description = "A cross-platform STB and IPTV player client"
 requires-python = ">=3.14"
 dependencies = [

--- a/update_checker.py
+++ b/update_checker.py
@@ -227,6 +227,8 @@ def show_update_dialog(update_info: dict):
         browser_btn = msg.addButton("Open Release Page", QMessageBox.ActionRole)
         msg.addButton(QMessageBox.Cancel)
 
+        # Ensure dialog is wide enough so buttons are not truncated
+        msg.setStyleSheet("QLabel{min-width: 350px;}")
         msg.exec_()
         clicked = msg.clickedButton()
 
@@ -240,6 +242,7 @@ def show_update_dialog(update_info: dict):
         # Fallback: running from source or no download URL available
         msg.setInformativeText("Would you like to open the release page?")
         msg.setStandardButtons(QMessageBox.Yes | QMessageBox.No)
+        msg.setStyleSheet("QLabel{min-width: 300px;}")
         if msg.exec_() == QMessageBox.Yes:
             import webbrowser
 
@@ -333,6 +336,7 @@ def _show_download_error(error_msg: str, release_url: str):
     error_dialog.setInformativeText(error_msg)
     open_btn = error_dialog.addButton("Open Release Page", QMessageBox.ActionRole)
     error_dialog.addButton(QMessageBox.Close)
+    error_dialog.setStyleSheet("QLabel{min-width: 300px;}")
 
     error_dialog.exec_()
     if error_dialog.clickedButton() == open_btn:
@@ -378,6 +382,7 @@ def _perform_windows_update(downloaded_path: str, release_url: str):
         error_dialog.setInformativeText(f"The update was downloaded to:\n{downloaded_path}")
         open_btn = error_dialog.addButton("Open Release Page", QMessageBox.ActionRole)
         error_dialog.addButton(QMessageBox.Close)
+        error_dialog.setStyleSheet("QLabel{min-width: 300px;}")
 
         error_dialog.exec_()
         if error_dialog.clickedButton() == open_btn:


### PR DESCRIPTION
## Summary
This PR fixes an issue where buttons in message dialogs were being truncated by setting a minimum width on dialog labels. This ensures dialogs are wide enough to display all content and buttons properly.

## Key Changes
- Added `setStyleSheet("QLabel{min-width: 350px;}")` to the main update dialog in `show_update_dialog()` to provide adequate width for the update notification
- Added `setStyleSheet("QLabel{min-width: 300px;}")` to three additional dialogs:
  - Fallback update dialog in `show_update_dialog()`
  - Download error dialog in `_show_download_error()`
  - Windows update error dialog in `_perform_windows_update()`
- Bumped version from 1.12.3 to 1.12.4

## Implementation Details
The fix applies consistent minimum width constraints across all message dialogs that display action buttons. The main update dialog uses a slightly larger minimum width (350px) compared to the error dialogs (300px) to accommodate longer informative text. This prevents button text from being cut off while maintaining a reasonable dialog size.

https://claude.ai/code/session_016UP8CNj62qGAPANVidKh82